### PR TITLE
PR to PR to PR: cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
   - mongo mydb_test --eval 'db.createUser({user:"travis",pwd:"test",roles:["readWrite"]});'
 
 before_install:
- - ./download_spark_dependencies.sh
+  - ./download_spark_dependencies.sh
 
 install:
   - sudo apt-get remove ipython

--- a/hyperopt/tests/test_spark.py
+++ b/hyperopt/tests/test_spark.py
@@ -448,9 +448,10 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
 
     def test_exception_when_spark_not_available(self):
         import hyperopt
+        orig_have_spark = hyperopt.spark._have_spark
         hyperopt.spark._have_spark = False
         try:
             with self.assertRaisesRegexp(Exception, "cannot import pyspark"):
                 SparkTrials(parallelism=4)
         finally:
-            hyperopt.spark._have_spark = True
+            hyperopt.spark._have_spark = orig_have_spark

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -17,10 +17,11 @@ set -e
 # if (got > 1 argument OR ( got 1 argument AND that argument does not exist)) then
 # print usage and exit.
 if [[ $# -gt 1 || ($# = 1 && ! -e $1) ]]; then
-echo "run_tests.sh [target]"
+echo "run_tests.sh [--no-spark] [target]"
 echo ""
 echo "Run python tests for this package."
-echo "  target -- either a test file or directory [default tests]"
+echo "  --no-spark : flag to tell this script to skip Apache Spark-related tests"
+echo "  target : either a test file or directory [default: tests]"
 if [[ ($# = 1 && ! -e $1) ]]; then
 echo
 echo "ERROR: Could not find $1"
@@ -47,7 +48,6 @@ PYSPARK_PYTHON=`which python`
 fi
 # Override the python driver version as well to make sure we are in sync in the tests.
 export PYSPARK_DRIVER_PYTHON=$PYSPARK_PYTHON
-python_major=$($PYSPARK_PYTHON -c 'import sys; print(".".join(map(str, sys.version_info[:1])))')
 
 echo $PYSPARK_PYTHON
 


### PR DESCRIPTION
This is a PR to this PR: https://github.com/hanyucui/hyperopt/pull/1/files with changes from my review.  I'll comment within about the changes.

The 1 remaining thing we haven't addressed in Max's comments is the running time of the `test_quadratic1_tpe` test.  I think it takes so long (~50 sec) with SparkTrials b/c Spark jobs have ~1 sec overhead, and there are 50 trials (max_evals) in that test.  That was an experimental use of other tests (leveraging the same test for both Trials and SparkTrials).  I recommend we revert our change to that test and do not run it with SparkTrials.  We could always copy that test and run it with smaller max_evals if we really want to.